### PR TITLE
增加 FrmTips、FrmAnchor对多显示屏的支持

### DIFF
--- a/HZH_Controls/HZH_Controls/Forms/FrmAnchor.cs
+++ b/HZH_Controls/HZH_Controls/Forms/FrmAnchor.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Assembly         : HZH_Controls
 // Created          : 08-08-2019
 //
@@ -245,10 +245,11 @@ namespace HZH_Controls.Forms
             timer1.Enabled = this.Visible;
             if (this.Visible)
             {
+                Screen currentScreen = Screen.FromControl(m_parentControl);
                 Point p = m_parentControl.Parent.PointToScreen(m_parentControl.Location);
                 int intX = 0;
                 int intY = 0;
-                if (p.Y + m_parentControl.Height + m_size.Height > Screen.PrimaryScreen.Bounds.Height)
+                if (p.Y + m_parentControl.Height + m_size.Height > currentScreen.Bounds.Height)
                 {
                     intY = p.Y - m_size.Height - 1;
                     blnDown = false;
@@ -259,9 +260,10 @@ namespace HZH_Controls.Forms
                     blnDown = true;
                 }
 
-                if (p.X + m_size.Width > Screen.PrimaryScreen.Bounds.Width)
+
+                if (p.X + m_size.Width > currentScreen.Bounds.Width)
                 {
-                    intX = Screen.PrimaryScreen.Bounds.Width - m_size.Width;
+                    intX = currentScreen.Bounds.Width - m_size.Width;
 
                 }
                 else
@@ -273,7 +275,7 @@ namespace HZH_Controls.Forms
                     intX += m_deviation.Value.X;
                     intY += m_deviation.Value.Y;
                 }
-                this.Location = new Point(intX, intY);
+                this.Location = ControlHelper.GetScreenLocation(currentScreen, intX, intY);
             }
         }
 

--- a/HZH_Controls/HZH_Controls/Forms/FrmTips.cs
+++ b/HZH_Controls/HZH_Controls/Forms/FrmTips.cs
@@ -246,7 +246,15 @@ namespace HZH_Controls.Forms
                                  {
                                      p.ShowAlign
                                  };
-                Size size = Screen.PrimaryScreen.Bounds.Size;
+                Screen currentScreen = Screen.PrimaryScreen;
+                
+                var firstTip = FrmTips.m_lstTips.FirstOrDefault();
+                if (firstTip != null && firstTip.Owner != null)
+                {
+                    currentScreen = Screen.FromControl(firstTip.Owner);
+                }
+
+                Size size = currentScreen.Bounds.Size;
                 foreach (var item in enumerable)
                 {
                     List<FrmTips> list = FrmTips.m_lstTips.FindAll((FrmTips p) => p.ShowAlign == item.Key.ShowAlign);
@@ -255,36 +263,36 @@ namespace HZH_Controls.Forms
                         FrmTips frmTips = list[i];
                         if (frmTips.InvokeRequired)
                         {
-                            frmTips.BeginInvoke(new MethodInvoker(delegate()
+                            frmTips.BeginInvoke(new MethodInvoker(delegate ()
                             {
                                 switch (item.Key.ShowAlign)
                                 {
                                     case ContentAlignment.BottomCenter:
-                                        frmTips.Location = new Point((size.Width - frmTips.Width) / 2, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, (size.Width - frmTips.Width) / 2, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
                                         break;
                                     case ContentAlignment.BottomLeft:
-                                        frmTips.Location = new Point(10, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, 10, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
                                         break;
                                     case ContentAlignment.BottomRight:
-                                        frmTips.Location = new Point(size.Width - frmTips.Width - 10, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, size.Width - frmTips.Width - 10, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
                                         break;
                                     case ContentAlignment.MiddleCenter:
-                                        frmTips.Location = new Point((size.Width - frmTips.Width) / 2, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, (size.Width - frmTips.Width) / 2, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
                                         break;
                                     case ContentAlignment.MiddleLeft:
-                                        frmTips.Location = new Point(10, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, 10, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
                                         break;
                                     case ContentAlignment.MiddleRight:
-                                        frmTips.Location = new Point(size.Width - frmTips.Width - 10, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, size.Width - frmTips.Width - 10, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
                                         break;
                                     case ContentAlignment.TopCenter:
-                                        frmTips.Location = new Point((size.Width - frmTips.Width) / 2, 10 + (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, (size.Width - frmTips.Width) / 2, 10 + (i + 1) * (frmTips.Height + 10));
                                         break;
                                     case ContentAlignment.TopLeft:
-                                        frmTips.Location = new Point(10, 10 + (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, 10, 10 + (i + 1) * (frmTips.Height + 10));
                                         break;
                                     case ContentAlignment.TopRight:
-                                        frmTips.Location = new Point(size.Width - frmTips.Width - 10, 10 + (i + 1) * (frmTips.Height + 10));
+                                        frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, size.Width - frmTips.Width - 10, 10 + (i + 1) * (frmTips.Height + 10));
                                         break;
                                     default:
                                         break;
@@ -296,31 +304,31 @@ namespace HZH_Controls.Forms
                             switch (item.Key.ShowAlign)
                             {
                                 case ContentAlignment.BottomCenter:
-                                    frmTips.Location = new Point((size.Width - frmTips.Width) / 2, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, (size.Width - frmTips.Width) / 2, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
                                     break;
                                 case ContentAlignment.BottomLeft:
-                                    frmTips.Location = new Point(10, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, 10, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
                                     break;
                                 case ContentAlignment.BottomRight:
-                                    frmTips.Location = new Point(size.Width - frmTips.Width - 10, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, size.Width - frmTips.Width - 10, size.Height - 100 - (i + 1) * (frmTips.Height + 10));
                                     break;
                                 case ContentAlignment.MiddleCenter:
-                                    frmTips.Location = new Point((size.Width - frmTips.Width) / 2, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, (size.Width - frmTips.Width) / 2, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
                                     break;
                                 case ContentAlignment.MiddleLeft:
-                                    frmTips.Location = new Point(10, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, 10, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
                                     break;
                                 case ContentAlignment.MiddleRight:
-                                    frmTips.Location = new Point(size.Width - frmTips.Width - 10, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, size.Width - frmTips.Width - 10, size.Height - (size.Height - list.Count * (frmTips.Height + 10)) / 2 - (i + 1) * (frmTips.Height + 10));
                                     break;
                                 case ContentAlignment.TopCenter:
-                                    frmTips.Location = new Point((size.Width - frmTips.Width) / 2, 10 + (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, (size.Width - frmTips.Width) / 2, 10 + (i + 1) * (frmTips.Height + 10));
                                     break;
                                 case ContentAlignment.TopLeft:
-                                    frmTips.Location = new Point(10, 10 + (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, 10, 10 + (i + 1) * (frmTips.Height + 10));
                                     break;
                                 case ContentAlignment.TopRight:
-                                    frmTips.Location = new Point(size.Width - frmTips.Width - 10, 10 + (i + 1) * (frmTips.Height + 10));
+                                    frmTips.Location = ControlHelper.GetScreenLocation(currentScreen, size.Width - frmTips.Width - 10, 10 + (i + 1) * (frmTips.Height + 10));
                                     break;
                                 default:
                                     break;

--- a/HZH_Controls/HZH_Controls/Helpers/ControlHelper.cs
+++ b/HZH_Controls/HZH_Controls/Helpers/ControlHelper.cs
@@ -1562,5 +1562,18 @@ namespace HZH_Controls
 
             return Color.FromArgb(color.A, (int)red, (int)green, (int)blue);
         }
+        
+        
+        /// <summary>
+        /// 相对于屏幕显示的位置
+        /// </summary>
+        /// <param name="screen">窗体需要显示的屏幕</param>
+        /// <param name="left">left</param>
+        /// <param name="top">top</param>
+        /// <returns></returns>
+        public static Point GetScreenLocation(Screen screen,int left,int top)
+        {
+            return new Point(screen.Bounds.Left + left, screen.Bounds.Top + top);
+        }
     }
 }


### PR DESCRIPTION
##更改原因
目前输入控件的小键盘、气泡显示窗体只显示在主屏幕，多屏状况下，当应用程序显示在副屏幕时，可能无法看到这些信息
##更改说明
ControlHelper.cs：增加方法GetScreenLocation，计算显示在指定屏幕的位置
FrmAnchor.cs ：修改 ReshowTips方法，增加对多屏的支持
FrmAnchor.cs：修改FrmAnchor_VisibleChanged方法，增加对多屏的支持